### PR TITLE
feat: 增加配置仓库地址变量

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM node:6.10.2-slim
 
 # Working enviroment
 ENV APPDIR /var/app/cnpmjs.org
+ENV CNPMJS_REPOSITORY cnpm/cnpmjs.org
 ENV CNPMJS_ORG_VERSION 2.19.4
 
 RUN \
@@ -13,7 +14,7 @@ RUN \
 USER www-data
 
 RUN \
-  wget -P /tmp https://github.com/cnpm/cnpmjs.org/archive/${CNPMJS_ORG_VERSION}.tar.gz && \
+  wget -P /tmp https://github.com/${CNPMJS_REPOSITORY}/archive/${CNPMJS_ORG_VERSION}.tar.gz && \
   tar xvzf /tmp/${CNPMJS_ORG_VERSION}.tar.gz -C /var/app && \
   mv /var/app/cnpmjs.org-${CNPMJS_ORG_VERSION} ${APPDIR}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM node:6.10.2-slim
 
 # Working enviroment
 ENV APPDIR /var/app/cnpmjs.org
-ENV CNPMJS_REPOSITORY cnpm/cnpmjs.org
-ENV CNPMJS_ORG_VERSION 2.19.4
+ENV CNPMJS_REPOSITORY zuibunan/cnpmjs.org
+ENV CNPMJS_ORG_VERSION 3.0.0-rc.21
 
 RUN \
   mkdir /var/app && \

--- a/README.md
+++ b/README.md
@@ -2,18 +2,20 @@
 
 docker image of [cnpmjs.org](https://cnpmjs.org/), the "Company NPM" by alibaba ![nodejs-version-badge](https://img.shields.io/badge/node.js->=_6-blue.svg?style=flat-square) ![cnpmjs.org-version-badge](https://img.shields.io/badge/cnpm-2.19.4-blue.svg?style=flat-square)
 
-https://hub.docker.com/r/hbrls/cnpmjs/
+https://hub.docker.com/r/zuibunan/cnpmjs
 
 # Easy
 
-    $ docker pull hbrls/cnpm:0.0.5
+    $ docker pull zuibunan/cnpmjs
     $ docker run -d \
+                 -e CNPMJS_REPOSITORY=zuibunan/cnpmjs.org \
+                 -e CNPMJS_ORG_VERSION=3.0.0-rc.21 \
                  -p 7001:7001 \
                  -p 7002:7002 \
                  -v /path/to/config:/var/app/cnpmjs.org/config \
                  -v /path/to/customize/README.md:/var/app/cnpmjs.org/docs/web/readme.md \
                  -v /path/to/storage:/var/www \
-                 --name cnpm hbrls/cnpm:0.0.5
+                 --name cnpm zuibunan/cnpmjs
 
 # Reference
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ https://hub.docker.com/r/zuibunan/cnpmjs
 
     $ docker pull zuibunan/cnpmjs
     $ docker run -d \
-                 -e CNPMJS_REPOSITORY=zuibunan/cnpmjs.org \
-                 -e CNPMJS_ORG_VERSION=3.0.0-rc.21 \
                  -p 7001:7001 \
                  -p 7002:7002 \
                  -v /path/to/config:/var/app/cnpmjs.org/config \


### PR DESCRIPTION
目前的docker镜像启动时只能指定版本，不能配置仓库，官方仓库很久不发布版本，导致使用 docker 镜像无法使用最新版本的cnpm

可以指定仓库后，用户就可以自己从官方仓库fork并发布版本，无须等待官方发布版本就能体验最新的cnpmjs